### PR TITLE
remove error catch on BodyParser when calling Validate() on a struct.…

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -16,10 +16,7 @@ import (
 type CanValidate struct{}
 
 func (v CanValidate) Validate(c *fiber.Ctx, req interface{}) *ValidationError {
-	err := c.BodyParser(req)
-	if err != nil {
-		return &ValidationError{error: err}
-	}
+	_ = c.BodyParser(req)
 
 	if vErr := validateRequest(req); vErr != nil {
 		return &ValidationError{bag: vErr}


### PR DESCRIPTION
… allow validateRequest() to propagate errors instead